### PR TITLE
Restrict crons to production environment

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -66,7 +66,11 @@ hooks:
 crons:
     magento:
         spec: "* * * * *"
-        cmd: "php bin/magento cron:run"
+        cmd: |
+            # Run crons only on `master` branch
+            if [ "$PLATFORM_BRANCH" = master ]; then
+                "php bin/magento cron:run"
+            fi
 
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Cron jobs are usually not required for non-production environments. Most customers disable them from my experience. Therefore, this small patch makes that behavior default.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Clone the template and branch the production (master, main, ...) environment.
2. Check that the non-production environment is not running cron jobs.
3. Check that the production environment is running cron jobs.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
