### PR TITLE
Grant workers access to app storage

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -29,7 +29,7 @@ relationships:
     redis: cache:redis
 
 # The size of the persistent disk of the application (in MB).
-disk: 2048
+disk: 400
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
@@ -37,16 +37,20 @@ mounts:
         source: local
         source_path: "var"
     "/generated":
-        source: local
+        source: service
+        service: shared-magento-storage
         source_path: "generated"
     "/pub/media":
-        source: local
+        source: service
+        service: shared-magento-storage
         source_path: "media"
     "/pub/static":
-        source: local
+        source: service
+        service: shared-magento-storage
         source_path: "static"
     "/.config":
-        source: local
+        source: service
+        service: shared-magento-storage
         source_path: "config"
 
 # The hooks executed at various points in the lifecycle of the application.

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -4,3 +4,7 @@ db:
 
 cache:
     type: redis:3.2
+
+shared-magento-storage:
+    type: network-storage:2.0
+    disk: 1648


### PR DESCRIPTION
### Warning

This change fixes the template but it is not compatible with Lando. See https://github.com/lando/platformsh/issues/68

### Description (*)
This resolves an issue with the deploy script only making the deployed configuration available to the app but not the worker by changing the storage configuration to network storage.

### Fixed Issues (if relevant)
1. [Health al](https://github.com/platformsh-templates/magento2ce/issues/23)

### Manual testing scenarios (*)
1. Create project from template
2. Manually trigger the worker command within the worker container `platform ssh --worker app--queue 'bin/magento queue:consumers:start async.operations.all --single-thread --max-messages=10000'`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
