### PR TITLE
Make sure to set the db password

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -176,6 +176,7 @@ class MagentoDeployer
                     '--db-host='.$database['host'],
                     '--db-name='.$database['path'],
                     '--db-user='.$database['username'],
+                    '--db-password='.$database['password'],
                     '--backend-frontname=admin',
                     '--language=en_US',
                     '--currency=USD',

--- a/deploy.php
+++ b/deploy.php
@@ -163,6 +163,7 @@ class MagentoDeployer
         $database = self::getRelationship('database');
         $search = self::getRelationship('search');
         $installFile = self::$FILE_PATHS['installed'];
+        $mysqlPassword = $database['password'];
 
         return [
             'Installing Magento 2.3' => [
@@ -207,8 +208,8 @@ class MagentoDeployer
                 'args' => [
                     "-h{$database['host']}",
                     "-u{$database['username']}",
-                    $database['password'] ?? "-p{$database['password']}", // Password, but only if there is one
-                    $database['path'],
+                    "--password='{$mysqlPassword}'",
+                    "-D {$database['path']}",
                     "-e \"insert into admin_passwords (user_id, password_hash, expires, last_updated) values (1, '123456789:2', 1, 1435156243);\"",
                 ],
                 'custom_fail_message' => 'WARNING! Failed to expire admin password. Please login to /admin and reset the password.',


### PR DESCRIPTION
## Description

Current deploy setup doesn't set the db password. This causes failure in a (non-platformsh, DDEV) environment where there actually is a password.

## Related Issue

* https://github.com/platformsh-templates/magento2ce/issues/55

## Motivation and Context

DDEV wants to be able to install using this template. 

* https://github.com/ddev/ddev-platformsh/issues/95

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [ ] I have read the contribution guide
- [ ] I have created an issue following the issue guide
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
